### PR TITLE
Do not crash when returning with empty plain-text mail

### DIFF
--- a/chrome/content/exteditor.js
+++ b/chrome/content/exteditor.js
@@ -239,7 +239,9 @@ function updateEditor() {
         } catch (e) {
             // The selection did not exist yet. Everything should be fine
         }
-        editor.QueryInterface(Components.interfaces.nsIEditorMailSupport).insertTextWithQuotations(messageText);
+        if (messageText) {
+            editor.QueryInterface(Components.interfaces.nsIEditorMailSupport).insertTextWithQuotations(messageText);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #11 

Deletes, but does not attempt to overwrite editor contents with an empty message.