### PR TITLE
Fix pref window style

### DIFF
--- a/chrome/content/settings.xul
+++ b/chrome/content/settings.xul
@@ -1,5 +1,5 @@
 <?xml version="1.0"?> 
-<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://messenger/skin/" type="text/css"?>
 
 <!DOCTYPE dialog SYSTEM "chrome://exteditor/locale/exteditor.dtd">
 


### PR DESCRIPTION
Currently the layout of the preference window is somewhat broken. It looks like `chrome://global/skin/` has been removed.