### PR TITLE
Fix layout of the pref dialog

### DIFF
--- a/chrome/content/exteditor.css
+++ b/chrome/content/exteditor.css
@@ -44,3 +44,15 @@ toolbar[iconsize="small"] #exteditor_bt[label="Vim"] {
 toolbar[iconsize="small"] #exteditor_bt[label="Vi"] {
     list-style-image: url("chrome://exteditor/content/vim16.png");
 }
+
+groupbox {
+    margin-top: 1em;
+}
+groupbox > caption {
+    margin-top: -1.5em;
+    padding: 0.5em 1em 0;
+}
+groupbox > caption * {
+    display: inline-block;
+    background: threedface;
+}

--- a/chrome/content/settings.xul
+++ b/chrome/content/settings.xul
@@ -1,5 +1,9 @@
-<?xml version="1.0"?> 
-<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://messenger/skin/" type="text/css"?>
+
+<?xml-stylesheet
+    href="chrome://exteditor/content/exteditor.css"
+    type="text/css"?>
 
 <!DOCTYPE dialog SYSTEM "chrome://exteditor/locale/exteditor.dtd">
 
@@ -22,9 +26,10 @@
 
     <broadcaster id="exteditor_brcstEditHeaders"/>
 
+    <description value="&exteditor-settings.title;"/>
 
-
-    <groupbox><caption id="exteditor_exe" label="&exteditor_exe.label;"/>
+    <groupbox>
+        <caption><label id="exteditor_exe" value="&exteditor_exe.label;"/></caption>
         <vbox align="stretch">
             <hbox align="center">
                 <label id="exteditor_editor" value="&exteditor_editor.value;"/>


### PR DESCRIPTION
Workaround to broken layout. It looks like `chrome://global/skin/` has been removed, and `chrome://messenger/skin` is not drop-in compatible.