### PR TITLE
Restore the compose window when the editor executable is not found

### DIFF
--- a/chrome/content/exteditor.js
+++ b/chrome/content/exteditor.js
@@ -123,7 +123,11 @@ function launchExtEditor() {
 
     var params = new Array(file);
     editorObserver = new extEditorObserver();
-    extEditorRunProgram(prefNotifierExe, params, editorObserver); // non blocking call
+    const launched = extEditorRunProgram(prefNotifierExe, params, editorObserver); // non blocking call
+
+    if (!launched) {
+      setEditorDisabled(false);
+    }
 }
 
 


### PR DESCRIPTION
Fixes #19.