### PR TITLE
Plug observer leak of the external editor process

### DIFF
--- a/chrome/content/exteditor.js
+++ b/chrome/content/exteditor.js
@@ -122,6 +122,9 @@ function launchExtEditor() {
     extEditorWriteFile(content, prefEditorUnicode, file);
 
     var params = new Array(file);
+    if (editorObserver) {
+        editorObserver.unregister();
+    }
     editorObserver = new extEditorObserver();
     extEditorRunProgram(prefNotifierExe, params, editorObserver); // non blocking call
 }


### PR DESCRIPTION
It looks like there is a slight memory leak on launching the external process. Set `/bin/true` as a editor and repeatedly press the button to reproduce.

```
// type this in the console to look increasing number of observers
for (let n=0, e = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService).enumerateObservers("extEditorObserver"); e.hasMoreElements();) { console.log(++n, e.getNext()) }
```

https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIObserver#Example

> Destruction - this should be fired once you're done observing (for example a window's unload event). Failure to do so may result in memory leaks

I fear that this may not be the right place to fix. Maybe use a weak reference?

**Edit:** I found a less aggressive way. It should leak no more than one observer.