### PR TITLE
Fix error on opening a filepicker

### DIFF
--- a/chrome/content/pref.js
+++ b/chrome/content/pref.js
@@ -6,23 +6,20 @@ You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // This needs: chrome://global/content/nsUserSettings.js
 
+var Services;
+Services = Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+
 // compat taken from http://qiita.com/sayamada/items/d6d26a3c2e9613854019
 var nsPreferences;
 nsPreferences = nsPreferences || ({
-    mPrefService: Components.classes["@mozilla.org/preferences-service;1"]
-        .getService(Components.interfaces.nsIPrefService)
-        .getBranch(""),
+    mPrefService: Services.prefs.getBranch(""),
     copyUnicharPref: function (key, defaultVal) {
         if (defaultVal === undefined) {
             defaultVal = "";
         }
         var val = undefined;
         try {
-            if ("getStringPref" in this.mPrefService) {
-                val = this.mPrefService.getStringPref(key);
-            } else {
-                val = this.mPrefService.getComplexValue(key, Components.interfaces.nsISupportsString).data;
-            }
+            val = this.mPrefService.getStringPref(key);
         } catch (e) {
             console.log(e);
         }
@@ -33,14 +30,7 @@ nsPreferences = nsPreferences || ({
         }
     },
     setUnicharPref: function (key, val) {
-        if ("setStringPref" in this.mPrefService) {
-            this.mPrefService.setStringPref(key, val);
-        } else {
-            var str = Components.classes["@mozilla.org/supports-string;1"]
-                .createInstance(Components.interfaces.nsISupportsString);
-            str.data = val;
-            this.mPrefService.setComplexValue(key, Components.interfaces.nsISupportsString, str);
-        }
+        this.mPrefService.setStringPref(key, val);
     },
     getBoolPref: function (key, defaultVal) {
         try {


### PR DESCRIPTION
>Somehow it was working until Thunderbird 68 but we needed to import them to use.
>Also, removed old compatibility call since this version won't support Thunderbird 58 or former.
>
>See: https://bugzilla.mozilla.org/show_bug.cgi?id=1471811

This commit was originally for #32, but it looks like this patch is needed to work with Thunderbird 60.9.
(Cherry picked from 967de2488299e63f7324a52149d7a7aa21d478c7)