### PR TITLE
Addresses passed to the external editor should be separated with comma-and-space, not only comma 

### DIFF
--- a/chrome/content/exteditor.js
+++ b/chrome/content/exteditor.js
@@ -137,7 +137,7 @@ function launchExtEditor() {
  * @returns {string} unescaped comma-separated list of email address
  */
 function normalizeRecipients(fieldValue) {
-    return gMsgCompose.compFields.splitRecipients(fieldValue, false, {}).join(",");
+    return gMsgCompose.compFields.splitRecipients(fieldValue, false, {}).join(", ");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, addresses on header editing are separated with comma only (which is a bit uncomfortable):

> To: foo@example.com,bar@example.com,baz@example.com

Before #46, addresses were separated with comma and space like:
> To: foo@example.com, bar@example.com, baz@example.com

This change restores that spaces between addresses.