### PR TITLE
Make addresses with comma(s) in the name roundtrip

### DIFF
--- a/chrome/content/exteditor.js
+++ b/chrome/content/exteditor.js
@@ -137,7 +137,19 @@ function launchExtEditor() {
  * @returns {string} unescaped comma-separated list of email address
  */
 function normalizeRecipients(fieldValue) {
-    return gMsgCompose.compFields.splitRecipients(fieldValue, false, {}).join(", ");
+    const headerParser = MailServices.headerParser;
+    return gMsgCompose.compFields.splitRecipients(fieldValue, false, {})
+        .map((addr) => {
+            try {
+                const [{ name, email }] = headerParser.makeFromDisplayAddress(addr, {});
+                if (name !== undefined && email !== undefined) {
+                    return headerParser.makeMimeAddress(name, email);
+                }
+            } catch (e) {
+            }
+            return addr;
+        })
+        .join(", ");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #54 the bug where address like `["To: foo, bar<foobar@example.com>"]`
is broken apart as `["To: foo <>", "To: bar <foobar@example.com>"]`
after editing in the external editor.
Quoting the name part like `"foo, bar" <foobar@example.com>` before
passing to external editor (which was the case before applying #46 :( )
saves them from split.