### PR TITLE
Keep quoted text after as it is in plain-text mode

### DIFF
--- a/chrome/content/exteditor.js
+++ b/chrome/content/exteditor.js
@@ -261,7 +261,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/.
                 // The selection did not exist yet. Everything should be fine
             }
             if (messageText) {
-                editor.insertText(messageText);
+                editor.insertTextWithQuotations(messageText);
             }
         }
     }


### PR DESCRIPTION
Thunderbird adds an extra white-space in front of the lines that starts with the greater-than symbol (">"). This symbol is the quotation marker for plain-text messages.

To add the quoted text, in plain-text mode, it is necessary to call another function from the Thunderbird's interface, made specifically for this purpose.

It addresses the issue #66.